### PR TITLE
added the correct variable REDISCLOUD_URL, in config.yml file

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDISCLOUD_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: Resistenfance_production


### PR DESCRIPTION
# Added : 

- Le nom de variable généré par défaut par rails à été changé pour "REDISCLOUD_URL", qui doit correspondre à ce qui est rentré de base sur heroku !

C'est assez important sinon ça fonctionnera pas