### PR TITLE
front audio-message & add AmplitudeJS for the player

### DIFF
--- a/app/assets/stylesheets/components/_audio_card.scss
+++ b/app/assets/stylesheets/components/_audio_card.scss
@@ -1,0 +1,51 @@
+.audio-card {
+  display: flex;
+  background-color: white;
+  border-radius: 20px;
+  width: 90%;
+  height: 180px;
+  box-shadow: 0 0 15px rgba(0,0,0,0.2);
+  .audio-card-avatar {
+    width: 25%;
+    padding: 15px;
+    img {
+      width: 100%;
+      height: 100%;
+      border-radius: 20px;
+    }
+  }
+  .audio-card-body {
+    padding: 15px 15px 15px 0px;
+    width: 75%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    .pseudo {
+      color: $black;
+      margin: 0px;
+      .user-link {
+        color: $black;
+      }
+    }
+    .grade {
+      color: $red;
+      margin: 0px;
+    }
+    .player {
+      width: 100%;
+      height: 60%;
+      background-color: #F65A6A;
+      border-radius: 25px;
+      display: flex;
+      audio {
+        box-shadow: 0 0 15px rgba(0,0,0,0.2);
+        border-radius: 25px;
+        width: 100%;
+        margin-top: 35px;
+      }
+    }
+    .audio-message-comments {
+      display: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -1,20 +1,17 @@
 // messages
 .message-form {
-    width: 40%;
+    display: inline;
     background-color: white;
-    padding: 1rem;
     margin: auto;
   }
-  
+
   #search-form {
     display: flex;
-    flex-direction: column;
+    flex-flow: row wrap;
     align-items: center;
-  
+
     .submit-button {
-      margin-top: 0.75rem;
-      padding: 0.5rem 1rem;
-      width: 33.333%;
+      width: 30%;
       border-radius: 0.25rem;
       transition-duration: 0.25s;
     }
@@ -22,14 +19,13 @@
       background-color: #3182ce;
     }
   }
-  
+
   #form {
-    padding: 0.75rem 0.5rem;
-    width: 100%;
+    width: 70%;
     border-radius: 0.25rem;
     line-height: 1.25;
   }
-  
+
   // sign-in, sign-up
   .sign-in-form, .sign-up-form{
     position: absolute;
@@ -48,7 +44,7 @@
         padding-left: 3rem;
     }
 }
- 
+
 .sign-up-form{
   margin-top: 15%;
 }

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -6,3 +6,4 @@
 @import "grid";
 @import "page";
 @import "form";
+@import "audio_card";

--- a/app/assets/stylesheets/pages/_index_audios.scss
+++ b/app/assets/stylesheets/pages/_index_audios.scss
@@ -21,50 +21,14 @@
   width: 60vw;
     .radio-title {
       margin-top: 150px;
+      h6 {
+        color: $red;
+      }
     }
     .audio-cards {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
     grid-gap: 10px;
     grid-auto-rows: auto;
-      .audio-card {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      grid-gap: 15px;
-      grid-auto-rows: auto;
-      background-color: red;
-      border-radius: 20px;
-      width: 80%;
-      box-shadow: 0 0 15px rgba(0,0,0,0.2);
-      padding: 10px;
-        .pseudo {
-        color: $black;
-        grid-column-start: 1;
-        grid-row: 2;
-        align-self: center;
-        margin: 0;
-        }
-        .grade {
-        color: $dark-grey;
-        grid-column-start: 2;
-        grid-row: 2;
-        align-self: center;
-        margin: 0;
-        color: $red;
-        }
-        .player {
-        grid-column: 2 / 3;
-        grid-row: 3;
-        align-self: center;
-        margin: 0;
-        }
-        audio {
-        box-shadow: 0 0 15px rgba(0,0,0,0.2);
-        border-radius: 25px;
-        }
-      }
-    }
-    .user-link {
-      color: $black;
     }
   }

--- a/app/views/audio_messages/index.html.erb
+++ b/app/views/audio_messages/index.html.erb
@@ -5,54 +5,21 @@
   <div class="right">
     <div class="radio-title">
       <h2>Radio Centre Aéré</h2>
-      <p>Les discours des membres de la résistance</p>
+      <h6>Les discours des membres de la résistance</h6>
     </div>
     <% if @audio_messages.empty? %>
     <div>
       <h2>Pas de messages publiés!</h2>
     </div>
     <% else %>
-    <% @audio_messages.each do |audio_message| %>
-    <div class="audio-cards">
-      <div class="audio-card">
-        <% if audio_message.user.avatar.nil? %>
-        <%= image_tag "avatars/krillin.jpeg" %>
-        <% else %>
-        <div class="card-avatar">
-          <%= image_tag "avatars/#{audio_message.user.avatar}.jpeg" %>
-        </div>
-        <% end %>
-        <h2 class="pseudo">
-          <%= link_to audio_message.user.pseudo, resistenfant_path(audio_message.user.id), class: "user-link" %>
-        </h2>
-        <p class="grade">
-          <%= audio_message.user.grade %>
-        </p>
-        <div class="player">
-          <% if audio_message.audio_file.attached? == false %>
-          <p>Pas d'audio</p>
-          <% else %>
-          <%= audio_tag rails_blob_path(audio_message.audio_file), controls: true %>
-          <% end %>
-        </div>
-        <div id="comments-list" class="comments">
-          <% @comments.each do |comment| %>
-          <% if comment.audio_message_id == audio_message.id %>
-          <%= render "comments/comment", comment: comment, user: comment.user %>
-          <% end %>
-          <% end %>
-        </div>
-        <div class="message-form">
-          <form id="search-form" class="">
-            <input id="form" class="" type="text" placeholder="Donnes tes impressions sur le message audio !" aria-label="Commentaire">
-            <input type="submit" value="Oui chef !" class="submit-button">
-          </form>
-        </div>
-      </div>
-      <% end %>
-    </div>
+    <%= render 'shared/audio_card' %>
     <% end %>
   </div>
 </div>
 
 <%= javascript_pack_tag 'message_creator' %>
+
+
+
+
+

--- a/app/views/shared/_audio_card.html.erb
+++ b/app/views/shared/_audio_card.html.erb
@@ -1,0 +1,45 @@
+<% @audio_messages.each do |audio_message| %>
+  <div class="audio-cards">
+    <div class="audio-card">
+      <div class="audio-card-avatar">
+        <% if audio_message.user.avatar.nil? %>
+          <%= image_tag "avatars/krillin.jpeg" %>
+        <% else %>
+          <%= image_tag "avatars/#{audio_message.user.avatar}.jpeg" %>
+        <% end %>
+      </div>
+      <div class="audio-card-body">
+        <div class="identity">
+          <h4 class="pseudo">
+            <%= link_to audio_message.user.pseudo, resistenfant_path(audio_message.user.id), class: "user-link" %>
+          </h4>
+          <h6 class="grade">
+            <%= audio_message.user.grade %>
+          </h6>
+        </div>
+        <div class="player">
+          <% if audio_message.audio_file.attached? == false %>
+            <p>Pas d'audio</p>
+          <% else %>
+            <%= audio_tag rails_blob_path(audio_message.audio_file), controls: true %>
+          <% end %>
+        </div>
+        <div class="audio-message-comments">
+          <div id="comments-list">
+            <% @comments.each do |comment| %>
+              <% if comment.audio_message_id == audio_message.id %>
+                <%= render "comments/comment", comment: comment, user: comment.user %>
+              <% end %>
+            <% end %>
+          </div>
+          <div class="message-form">
+            <form id="search-form" class="">
+              <input id="form" class="" type="text" placeholder="Donnes tes impressions sur le message audio !" aria-label="Commentaire">
+              <input type="submit" value="Oui chef !" class="submit-button">
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.0.1",
+    "amplitudejs": "^5.0.3",
     "bootstrap": "^4.4.1",
     "jquery": "^3.5.0",
     "popper.js": "^1.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,6 +1084,11 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
+amplitudejs@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/amplitudejs/-/amplitudejs-5.0.3.tgz#5f45936d153d7104698f4a736dd300c28e583a5b"
+  integrity sha512-A093+9kKaOyRiSYLour7cA0zcHEhgmF4gfj0q9a5mPaSt6uACHtNHKdHnH4vG9NUZT1X4oAZ+Z0c9q005iipHw==
+
 ansi-colors@^3.0.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"


### PR DESCRIPTION
Pour le front de la page audio_messages/index


- Création d'un Partial _audio_card.html.erb  à utiliser pour les messages
  *utilisable avec `<%= render 'shared/audio_card' %>`* 
- Création du fichier audio_card.scss 
- Ajout de AmplitudeJS pour le design du player
  **Nécessite un yarn install**

